### PR TITLE
Fix SPI blocking problem

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -49,9 +49,10 @@ impl Pins<SPI1>
 }
 
 impl<PINS> Spi<SPI1, PINS> {
-    pub fn spi1(spi: SPI1, pins: PINS, mode: Mode, speed: Hertz, clocks: Clocks) -> Self
+    pub fn spi1<F>(spi: SPI1, pins: PINS, mode: Mode, speed: F, clocks: Clocks) -> Self
     where
         PINS: Pins<SPI1>,
+        F: Into<Hertz>,
     {
         // NOTE(unsafe) This executes only during initialisation
         let rcc = unsafe { &(*RCC::ptr()) };
@@ -69,7 +70,7 @@ impl<PINS> Spi<SPI1, PINS> {
         // disable SS output
         spi.cr2.write(|w| w.ssoe().clear_bit());
 
-        let br = match clocks.pclk().0 / speed.0 {
+        let br = match clocks.pclk().0 / speed.into().0 {
             0 => unreachable!(),
             1...2 => 0b000,
             3...5 => 0b001,

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -8,7 +8,7 @@ use rcc::Clocks;
 use stm32f042::{SPI1, RCC};
 
 use gpio::gpioa::{PA5, PA6, PA7};
-use gpio::gpiob::{PB2, PB4, PB5};
+use gpio::gpiob::{PB3, PB4, PB5};
 use gpio::{AF0, Alternate};
 use time::{Hertz};
 
@@ -42,7 +42,7 @@ impl Pins<SPI1>
 }
 impl Pins<SPI1>
     for (
-        PB2<Alternate<AF0>>,
+        PB3<Alternate<AF0>>,
         PB4<Alternate<AF0>>,
         PB5<Alternate<AF0>>,
     ) {


### PR DESCRIPTION
The SPI peripheral's receive FIFO threshold was too high -- it expected two bytes, but only one was transferred before blocking. I've fixed that issue.

Going forward, `stm32f30x-hal` is a better reference than the `f103` for the SPI peripheral on the `f0x2` devices.

See the commit messages for more detailed explanations.